### PR TITLE
refactor: Rename `master` branch to `main`

### DIFF
--- a/.github/workflows/node-check-code.yaml
+++ b/.github/workflows/node-check-code.yaml
@@ -5,7 +5,7 @@ on:
     branches-ignore:
       - 'wip-**'
       - '**-wip'
-      - 'master'
+      - 'main'
       - 'alpha'
       - 'beta'
       - 'next'
@@ -17,6 +17,7 @@ jobs:
     env:
       CI: true
       NPM_READ_TOKEN: ${{ secrets.NPM_READ_AND_PUBLISH_TOKEN || secrets.NPM_READ_TOKEN }}
+      STABLE_RELEASE_BRANCH: 'main'
 
     runs-on: ubuntu-latest
 
@@ -30,7 +31,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v2
       - name: Fetch
-        run: git fetch --prune --unshallow && git fetch origin 'master:master'
+        run: git fetch --prune --unshallow && git fetch origin "$STABLE_RELEASE_BRANCH:$STABLE_RELEASE_BRANCH"
       - name: Use Node.js ${{ matrix.node-version }}
         uses: actions/setup-node@v1
         with:

--- a/.github/workflows/node-prerelease.yaml
+++ b/.github/workflows/node-prerelease.yaml
@@ -23,6 +23,7 @@ jobs:
       GPG_KEY_ID: ${{ secrets.SPQR_BOT_GPG_KEY_ID }}
       NPM_READ_TOKEN: ${{ secrets.NPM_READ_AND_PUBLISH_TOKEN || secrets.NPM_READ_TOKEN }}
       NPM_READ_AND_PUBLISH_TOKEN: ${{ secrets.NPM_READ_AND_PUBLISH_TOKEN }}
+      STABLE_RELEASE_BRANCH: 'main'
 
     runs-on: ubuntu-latest
 
@@ -40,7 +41,7 @@ jobs:
       - name: Fetch
         run: |
           git fetch --depth=1 origin +refs/tags/*:refs/tags/*
-          git fetch --unshallow origin 'master:master'
+          git fetch --unshallow origin "$STABLE_RELEASE_BRANCH:$STABLE_RELEASE_BRANCH"
           git fetch origin $(git symbolic-ref --short HEAD)
       - name: Use Node.js ${{ matrix.node-version }}
         uses: actions/setup-node@v1

--- a/.github/workflows/node-stable-release.yaml
+++ b/.github/workflows/node-stable-release.yaml
@@ -3,7 +3,7 @@ name: Stable release
 on:
   push:
     branches:
-      - 'master'
+      - 'main'
     paths-ignore:
       - '**/*.md'
       - 'docs/**'
@@ -21,6 +21,7 @@ jobs:
       GPG_KEY_ID: ${{ secrets.SPQR_BOT_GPG_KEY_ID }}
       NPM_READ_TOKEN: ${{ secrets.NPM_READ_AND_PUBLISH_TOKEN || secrets.NPM_READ_TOKEN }}
       NPM_READ_AND_PUBLISH_TOKEN: ${{ secrets.NPM_READ_AND_PUBLISH_TOKEN }}
+      STABLE_RELEASE_BRANCH: 'main'
 
     runs-on: ubuntu-latest
 
@@ -38,7 +39,7 @@ jobs:
       - name: Fetch
         run: |
           git fetch --depth=1 origin +refs/tags/*:refs/tags/*
-          git fetch --unshallow origin master
+          git fetch --unshallow origin $STABLE_RELEASE_BRANCH
       - name: Use Node.js ${{ matrix.node-version }}
         uses: actions/setup-node@v1
         with:
@@ -129,4 +130,4 @@ jobs:
         run: git push --tags origin $VERSION_STAGE
       - name: Update next branch
         if: success()
-        run: git fetch origin next && git checkout next && git merge --ff-only master && git push origin next
+        run: git fetch origin next && git checkout next && git merge --ff-only $STABLE_RELEASE_BRANCH && git push origin next

--- a/.skypilot/quick-release.yaml
+++ b/.skypilot/quick-release.yaml
@@ -1,5 +1,5 @@
 # These values override the settings in
-# https://github.com/skypilot-dev/quick-release/blob/master/src/scripts/quick-release.defaults.yaml
+# https://github.com/skypilot-dev/quick-release/blob/main/src/scripts/quick-release.defaults.yaml
 version: 1
 bot:
   # These values are used to sign commits & tags in GitHub Actions workflows


### PR DESCRIPTION
This change replaces the `master` branch with the `main` branch.

- The master branch has already been deleted
- `STABLE_RELEASE_BRANCH` has been set to `main` in each of the GitHub workflows

When this PR is merged, the version-bump automation should be able to compute a new version number relative to the `main` branch.

If that succeeds, we can push `main` to `next` to create a release.