### PR TITLE
feat: A prerelease branch can be designated as 'latest'

### DIFF
--- a/.github/workflows/node-prerelease.yaml
+++ b/.github/workflows/node-prerelease.yaml
@@ -98,8 +98,17 @@ jobs:
               if [[ $(yarn --silent is-published $VERSION) == true ]]; then
                 echo "$VERSION_TAG has already been published. Skipping publication."
               else
+                ACCESS=$(yarn --silent spqr-option prerelease.access)
                 yarn config set //registry.yarnpkg.com/:_authToken=$NPM_READ_AND_PUBLISH_TOKEN
-                yarn publish --access $(yarn --silent spqr-option prerelease.access) --non-interactive --tag $VERSION_STAGE
+                yarn publish --access $ACCESS --non-interactive --tag $VERSION_STAGE
+
+                # If this stage is designated as the latest stage, tag it as 'latest' in NPM
+                # (typically used with alpha or beta prereleases prior to the publication of the first release)
+                LATEST_STAGE=$(yarn --silent spqr-option prerelease.latestStage)
+                if test -n $LATEST_STAGE && [[ $LATEST_STAGE == $VERSION_STAGE ]]; then
+                  # Yarn (as at v1.22.5) throws an error when adding a tag, but the operation does succeed
+                  yarn tag add "$(yarn info --silent . name)@$VERSION" latest || true
+                fi
               fi
             fi
           else

--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ NPM packages. Two different types of automated releases are supported:
 
 The workflows are configured to automatically
 
--   publish a stable release on every push to `master`
+-   publish a stable release on every push to `main`
 -   publish a prerelease on every push to `alpha`, `beta`, or `next` branch
 
 Toolchain performs the following steps when a release is created. If any step fails, the release is
@@ -77,12 +77,24 @@ halted.
 -   Determine the next version number (based on commit messages)
 -   Create a version tag
 -   Publish the package to NPM (if publication is enabled)
+-   If the version stage is designated as the `latest` stage, tag the package as `latest`
 
 For stable releases, the workflow will also:
 
 -   Bump the version number in `package.json`
 -   Generate an updated `CHANGELOG.md`
 -   Commit these changes to the stable branch
+-   Tag the package as `latest`
+
+To designate a stage other than the stable-release branch as the `latest`
+stage, add the stage name to `.skypilot/quick-release.yaml`.
+
+Example: This setting designates the `beta` stage as the latest stage.
+
+```yaml
+prerelease:
+  latestStage: 'beta'
+```
 
 ### Convenience scripts
 


### PR DESCRIPTION
This change allows a prerelease stage to be designated as the "latest" stage, causing that stage's published packages to be tagged as `latest`.

This ability is useful prior to the first official release -- before the `main` branch has been published -- because otherwise 'latest' points to the first prerelease version and never changes. Once an official release is published, the `latestStage` setting should be removed from the config file.

Already implemented in `@skypilot/parsifal`, which served as a successful test case.