### PR TITLE
feat: Support NPM automation tokens

### DIFF
--- a/.github/workflows/node-check-code.yaml
+++ b/.github/workflows/node-check-code.yaml
@@ -16,7 +16,7 @@ jobs:
 
     env:
       CI: true
-      NPM_READ_TOKEN: ${{ secrets.NPM_READ_AND_PUBLISH_TOKEN || secrets.NPM_READ_TOKEN }}
+      NPM_READ_TOKEN: ${{ secrets.NPM_AUTOMATION_TOKEN || secrets.NPM_READ_AND_PUBLISH_TOKEN || secrets.NPM_READ_TOKEN }}
       STABLE_RELEASE_BRANCH: 'main'
 
     runs-on: ubuntu-latest

--- a/.github/workflows/node-prerelease.yaml
+++ b/.github/workflows/node-prerelease.yaml
@@ -21,8 +21,8 @@ jobs:
       CI: true
       GPG_KEY: ${{ secrets.SPQR_BOT_GPG_KEY }}
       GPG_KEY_ID: ${{ secrets.SPQR_BOT_GPG_KEY_ID }}
-      NPM_READ_TOKEN: ${{ secrets.NPM_READ_AND_PUBLISH_TOKEN || secrets.NPM_READ_TOKEN }}
-      NPM_READ_AND_PUBLISH_TOKEN: ${{ secrets.NPM_READ_AND_PUBLISH_TOKEN }}
+      NPM_READ_TOKEN: ${{ secrets.NPM_AUTOMATION_TOKEN || secrets.NPM_READ_AND_PUBLISH_TOKEN || secrets.NPM_READ_TOKEN }}
+      NPM_READ_AND_PUBLISH_TOKEN: ${{ secrets.NPM_AUTOMATION_TOKEN || ${{ secrets.NPM_READ_AND_PUBLISH_TOKEN }}
       STABLE_RELEASE_BRANCH: 'main'
 
     runs-on: ubuntu-latest

--- a/.github/workflows/node-stable-release.yaml
+++ b/.github/workflows/node-stable-release.yaml
@@ -19,8 +19,8 @@ jobs:
       CI: true
       GPG_KEY: ${{ secrets.SPQR_BOT_GPG_KEY }}
       GPG_KEY_ID: ${{ secrets.SPQR_BOT_GPG_KEY_ID }}
-      NPM_READ_TOKEN: ${{ secrets.NPM_READ_AND_PUBLISH_TOKEN || secrets.NPM_READ_TOKEN }}
-      NPM_READ_AND_PUBLISH_TOKEN: ${{ secrets.NPM_READ_AND_PUBLISH_TOKEN }}
+      NPM_READ_TOKEN: ${{ secrets.NPM_AUTOMATION_TOKEN || secrets.NPM_READ_AND_PUBLISH_TOKEN || secrets.NPM_READ_TOKEN }}
+      NPM_READ_AND_PUBLISH_TOKEN: ${{ secrets.NPM_AUTOMATION_TOKEN || ${{ secrets.NPM_READ_AND_PUBLISH_TOKEN }}
       STABLE_RELEASE_BRANCH: 'main'
 
     runs-on: ubuntu-latest


### PR DESCRIPTION
If `NPM_AUTOMATION_TOKEN` is defined in repo secrets, use it in preference to other `NPM_*` tokens