### PR TITLE
fix: Husky post-install script fails

### DIFF
--- a/package.json
+++ b/package.json
@@ -80,12 +80,12 @@
     "husky": "^5.1.1",
     "jest": "^26.6.3",
     "lint-staged": "^10.5.4",
+    "pinst": "^2.1.6",
     "typescript": "4.2.2"
   },
   "devDependencies": {
     "@babel/register": "^7.13.0",
     "@types/tmp": "^0.2.0",
-    "pinst": "^2.1.6",
     "tmp": "^0.2.1"
   },
   "peerDependencies": {},


### PR DESCRIPTION
Attempt to fix Husky post-install failure by moving `pinst` (required for the post-install) to prod dependencies.